### PR TITLE
[DM-16492] Configure Kafka InfluxDB Sink Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,29 @@ In this demo, the default topic is called `helloavro`.
    kafkaefd helloavro produce "Hello world"
    ```
 
+## InfluxDB installation (optional)
+
+Follow the [InfluxDB + Chronograf + Kapacitor (ICK) deployment](https://github.com/lsst-sqre/ick-deployment) instructions to install those components in the cluster.
+
+### InfluxDB Sink Connector configuration
+
+The [Landoop InfluxDB Sink Connector](https://docs.lenses.io/connectors/sink/influx.html) consumes Kafka Avro-serialized messages and send them to InfluxDB.
+
+From the `k8s-cluster` directory, connect to the Kafka Connect server:
+
+```bash
+./port-forward-kafka-connect.sh
+```
+
+From the `k8s-cluster/cp-kafka-connect` directory, configure the [Landoop InfluxDB Sink Connector](https://docs.lenses.io/connectors/sink/influx.html):
+
+```bash
+./configure-influxdb-connector.sh
+```
+
+With this example configuration the `kafkaefd helloavro` command will send messages to
+InfluxDB.
+
 ## Lessons learned
 
 ### Keys and partitioning

--- a/k8s-cluster/cp-helm-charts-values.yaml
+++ b/k8s-cluster/cp-helm-charts-values.yaml
@@ -1,0 +1,142 @@
+## ------------------------------------------------------
+## Zookeeper
+## ------------------------------------------------------
+cp-zookeeper:
+  enabled: true
+  servers: 3
+  image: confluentinc/cp-zookeeper
+  imageTag: 5.0.1
+  ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
+  ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+  imagePullSecrets:
+  #  - name: "regcred"
+  heapOptions: "-Xms512M -Xmx512M"
+  persistence:
+    enabled: true
+    ## The size of the PersistentVolume to allocate to each Zookeeper Pod in the StatefulSet. For
+    ## production servers this number should likely be much larger.
+    ##
+    ## Size for Data dir, where ZooKeeper will store the in-memory database snapshots.
+    dataDirSize: 5Gi
+    # dataDirStorageClass: ""
+
+    ## Size for data log dir, which is a dedicated log device to be used, and helps avoid competition between logging and snaphots.
+    dataLogDirSize: 5Gi
+    # dataLogDirStorageClass: ""
+  resources: {}
+  ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
+  ## and remove the curly braces after 'resources:'
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+## ------------------------------------------------------
+## Kafka
+## ------------------------------------------------------
+cp-kafka:
+  enabled: true
+  brokers: 3
+  image: confluentinc/cp-kafka
+  imageTag: 5.0.1
+  ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
+  ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+  imagePullSecrets:
+  #  - name: "regcred"
+  heapOptions: "-Xms512M -Xmx512M"
+  persistence:
+    enabled: true
+    # storageClass: ""
+    size: 5Gi
+  resources: {}
+  ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
+  ## and remove the curly braces after 'resources:'
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+## ------------------------------------------------------
+## Schema Registry
+## ------------------------------------------------------
+cp-schema-registry:
+  enabled: true
+  image: confluentinc/cp-schema-registry
+  imageTag: 5.0.1
+  ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
+  ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+  imagePullSecrets:
+  #  - name: "regcred"
+  heapOptions: "-Xms512M -Xmx512M"
+  resources: {}
+  ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
+  ## and remove the curly braces after 'resources:'
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+## ------------------------------------------------------
+## REST Proxy
+## ------------------------------------------------------
+cp-kafka-rest:
+  enabled: true
+  image: confluentinc/cp-kafka-rest
+  imageTag: 5.0.1
+  ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
+  ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+  imagePullSecrets:
+  #  - name: "regcred"
+  resources: {}
+  ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
+  ## and remove the curly braces after 'resources:'
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+## ------------------------------------------------------
+## Kafka Connect
+## ------------------------------------------------------
+cp-kafka-connect:
+  enabled: true
+  image: lsstsqre/cp-kafka-connect
+  imageTag: latest
+  ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
+  ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+  imagePullSecrets:
+  #  - name: "regcred"
+
+  pluginPath: "/usr/share/java,/etc/landoop/jars/lib"
+
+  resources: {}
+  ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
+  ## and remove the curly braces after 'resources:'
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+## ------------------------------------------------------
+## KSQL Server
+## ------------------------------------------------------
+cp-ksql-server:
+  enabled: true
+  image: confluentinc/cp-ksql-server
+  imageTag: 5.0.1
+  ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
+  ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+  imagePullSecrets:
+  #  - name: "regcred"
+  ksql:
+    headless: false

--- a/k8s-cluster/cp-kafka-connect/Dockerfile
+++ b/k8s-cluster/cp-kafka-connect/Dockerfile
@@ -1,0 +1,16 @@
+# Builds a docker image for Confluent Platform Kafka Connect with InfluxDB Sink
+# Connector from Landoop https://docs.lenses.io/connectors/sink/influx.html
+
+FROM confluentinc/cp-kafka-connect-base
+
+MAINTAINER afausti@lsst.org
+
+ARG CONNECTOR
+ARG CONNECTOR_VERSION
+
+RUN echo "Installing InfluxDB Sink Connector from Landoop ..." && \
+wget https://github.com/landoop/stream-reactor/releases/download/${CONNECTOR_VERSION}/kafka-connect-${CONNECTOR}-${CONNECTOR_VERSION}-${CONNECTOR_VERSION}-all.tar.gz && \
+tar -xvf kafka-connect-${CONNECTOR}-${CONNECTOR_VERSION}-${CONNECTOR_VERSION}-all.tar.gz -C . && \
+mkdir -p /etc/landoop/jars/lib && \
+mv kafka-connect-${CONNECTOR}-${CONNECTOR_VERSION}-${CONNECTOR_VERSION}-all.jar /etc/landoop/jars/lib && \
+chmod -R ag+w /etc/landoop/jars/lib

--- a/k8s-cluster/cp-kafka-connect/build-docker.sh
+++ b/k8s-cluster/cp-kafka-connect/build-docker.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+CONNECTOR="influxdb"
+CONNECTOR_VERSION="1.1.0"
+IMAGE="lsstsqre/cp-kafka-connect"
+IMAGE_TAG="latest"
+
+echo "Building CP Kafka Connect with InfluxDB Sink Connector from Landoop"
+docker build \
+    --build-arg CONNECTOR=${CONNECTOR} \
+    --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} \
+    -t ${IMAGE}:${IMAGE_TAG} \
+    -f Dockerfile .
+docker push ${IMAGE}:${IMAGE_TAG}

--- a/k8s-cluster/cp-kafka-connect/configure-influxdb-connector.sh
+++ b/k8s-cluster/cp-kafka-connect/configure-influxdb-connector.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Configure InfluxDB Sink Connector from Landoop
+# https://docs.lenses.io/connectors/sink/influx.html
+
+set -x
+
+echo "Configure InfluxDB Sink Connector from Landoop"
+curl -s -X POST -H 'Content-Type: application/json' \
+--data @connector-create.json http://localhost:8083/connectors

--- a/k8s-cluster/cp-kafka-connect/connector-create.json
+++ b/k8s-cluster/cp-kafka-connect/connector-create.json
@@ -1,0 +1,12 @@
+{
+  "name" : "influxdb-sink",
+  "config" : {
+    "connector.class" : "com.datamountaineer.streamreactor.connect.influx.InfluxSinkConnector",
+    "tasks.max" : "1",
+    "topics" : "helloavro",
+    "connect.influx.url" : "http://influxdb-influxdb.default:8086",
+    "connect.influx.db": "kafka",
+    "connect.influx.kcql": "INSERT INTO influxMeasure SELECT * FROM helloavro WITHTIMESTAMP sys_time()",
+    "connect.influx.username": "-"
+  }
+}

--- a/k8s-cluster/cp-kafka-connect/remove-influxdb-connector.sh
+++ b/k8s-cluster/cp-kafka-connect/remove-influxdb-connector.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Configure InfluxDB Sink Connector from Landoop
+# https://docs.lenses.io/connectors/sink/influx.html
+
+set -x
+
+echo "Configure InfluxDB Sink Connector from Landoop"
+curl -s -X DELETE -H 'Content-Type: application/json' http://localhost:8083/connectors/influxdb-sink

--- a/k8s-cluster/install-confluent-kafka.sh
+++ b/k8s-cluster/install-confluent-kafka.sh
@@ -7,4 +7,4 @@ helm repo add confluentinc https://raw.githubusercontent.com/confluentinc/cp-hel
 helm repo update
 
 # Install Kafka using TLS (see install-tiller.sh)
-helm install confluentinc/cp-helm-charts --name confluent-kafka --tls
+helm install -f cp-helm-charts-values.yaml confluentinc/cp-helm-charts --name confluent-kafka --tls

--- a/k8s-cluster/port-forward-kafka-connect.sh
+++ b/k8s-cluster/port-forward-kafka-connect.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Port forwarding Kafka Connect to http://localhost:8083
+
+set -x
+
+echo "Port forwarding Kafka Connect to http://localhost:8083"
+
+POD_NAME=$(kubectl get pods --namespace default -l "app=cp-kafka-connect,release=confluent-kafka" -o jsonpath="{.items[0].metadata.name}")
+kubectl --namespace default port-forward $POD_NAME 8083


### PR DESCRIPTION
- Build a container that installs the Landoop InfluxDB Sink Connector on top of the `cp-kafka-connect-base` docker image.
- Add custom configuration for Confluent Platform helm charts, in particular for the `cp-kafka-connect` component.
- Example configurtion for the Landoop InfluxDB Sink Connector which works with the Hello world for Avro demo.
