### PR TITLE
[DM-16776] Configure the InfluxDB sink connector to consume topics from the mock SAL Kafka producer

### DIFF
--- a/k8s-cluster/cp-kafka-connect/configure-influxdb-connector.sh
+++ b/k8s-cluster/cp-kafka-connect/configure-influxdb-connector.sh
@@ -7,4 +7,4 @@ set -x
 
 echo "Configure InfluxDB Sink Connector from Landoop"
 curl -s -X POST -H 'Content-Type: application/json' \
---data @connector-create.json http://localhost:8083/connectors
+--data @$1 http://localhost:8083/connectors

--- a/k8s-cluster/port-forward-influxdb.sh
+++ b/k8s-cluster/port-forward-influxdb.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Port forwarding InfluxDB to http://localhost:8086
+
+set -x
+
+echo "Port forwarding InfluxDB to http://localhost:8086"
+
+POD_NAME=$(kubectl get pods --namespace default -l "app=influxdb-influxdb,release=influxdb" -o jsonpath="{.items[0].metadata.name}")
+kubectl --namespace default port-forward $POD_NAME 8086

--- a/k8s-cluster/port-forward-schema-registry.sh
+++ b/k8s-cluster/port-forward-schema-registry.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Port forwarding Schema Registry to http://localhost:8081
+
+set -x
+
+echo "Port forwarding Schema Registry to http://localhost:8081"
+
+POD_NAME=$(kubectl get pods --namespace default -l "app=cp-schema-registry,release=confluent-kafka" -o jsonpath="{.items[0].metadata.name}")
+kubectl --namespace default port-forward $POD_NAME 8081


### PR DESCRIPTION
- Make `aiokafka` avro messages compatible with confluent wire format by adding the magic byte and the schema ID at the beginning of the message.
- New command to generate the InfluxDB Sink connector configuration from a list of topics