### PR TITLE
Monitor status of influxdb-sink kafka connector

### DIFF
--- a/k8s-apps/create-influxdb-sink.yaml
+++ b/k8s-apps/create-influxdb-sink.yaml
@@ -16,18 +16,8 @@ spec:
       - name: create-influxdb-sink
         image: lsstsqre/kafka-efd-demo:tickets-DM-17754
         imagePullPolicy: Always
-        command:
-          - "kafkaefd"
-          - "admin"
-          - "connectors"
-          - "create"
-          - "influxdb-sink"
-          - "--influxdb"
-          - "https://influxdb-efd-kafka.lsst.codes"
-          - "--database"
-          - "kafkaefd"
-          - "--daemon"
-          - "helloavro"
+        command: ["/bin/sh"]
+        args: ["-c", "kafkaefd admin connectors create influxdb-sink --influxdb https://influxdb-efd-kafka.lsst.codes --database efd --daemon $(kafkaefd admin topics list --inline --filter lsst.sal.*)"]
         env:
           - name: BROKER
             value: "confluent-cp-kafka-headless.kafka:9092"

--- a/k8s-apps/create-influxdb-sink.yaml
+++ b/k8s-apps/create-influxdb-sink.yaml
@@ -1,17 +1,20 @@
----
-apiVersion: batch/v1
-kind: Job
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: "create-influxdb-sink"
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "create-influxdb-sink"
   template:
     metadata:
       labels:
-        role: "create-influxdb-sink"
+        app: "create-influxdb-sink"
     spec:
       containers:
       - name: create-influxdb-sink
-        image: lsstsqre/kafka-efd-demo:tickets-DM-17461
+        image: lsstsqre/kafka-efd-demo:tickets-DM-17754
         imagePullPolicy: Always
         command:
           - "kafkaefd"
@@ -19,9 +22,11 @@ spec:
           - "connectors"
           - "create"
           - "influxdb-sink"
+          - "--influxdb"
+          - "https://influxdb-efd-kafka.lsst.codes"
           - "--database"
           - "kafkaefd"
-          - "--upload"
+          - "--daemon"
           - "helloavro"
         env:
           - name: BROKER
@@ -30,5 +35,3 @@ spec:
             value: "http://confluent-cp-schema-registry.kafka:8081"
           - name: KAFKA_CONNECT
             value: "http://confluent-cp-kafka-connect:8083"
-      restartPolicy: Never
-  backoffLimit: 4


### PR DESCRIPTION
- Add the `--daemon` option to monitor the status of the connector after its creation
- Replaces k8s job by deployment
- Auto-discovery of topics is possible with a combination of commands like this:

```
kafkaefd admin connectors create influxdb-sink --influxdb https://influxdb-efd-kafka.lsst.codes --database efd --daemon $(kafkaefd admin topics list --inline --filter lsst.sal.*)
```


