### PR TITLE
Small fix to saltransform

### DIFF
--- a/k8s-apps/saltransformer-deployment.yaml
+++ b/k8s-apps/saltransformer-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: mtm1m3ts
-        image: lsstsqre/kafka-efd-demo:tickets-DM-17500
+        image: lsstsqre/kafka-efd-demo:latest
         imagePullPolicy: Always
         command:
           - "kafkaefd"
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
       - name: mtm1m3ts
-        image: lsstsqre/kafka-efd-demo:tickets-DM-17500
+        image: lsstsqre/kafka-efd-demo:latest
         imagePullPolicy: Always
         command:
           - "kafkaefd"

--- a/k8s-apps/saltransformer-init.yaml
+++ b/k8s-apps/saltransformer-init.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: saltransformer
-        image: lsstsqre/kafka-efd-demo:tickets-DM-17500
+        image: lsstsqre/kafka-efd-demo:latest
         imagePullPolicy: Always
         command:
           - "kafkaefd"

--- a/kafkaefd/bin/saltransform.py
+++ b/kafkaefd/bin/saltransform.py
@@ -334,7 +334,7 @@ async def subsystem_transformer(*, loop, subsystem, kind, httpsession,
                     inbound_key, inbound_value)
 
                 TRANSFORM_TIME.observe(
-                    (datetime.datetime.now() - transform_start_time).seconds())
+                    (datetime.datetime.now() - transform_start_time).seconds)
 
                 # Use the fully-qualified schema name as the topic name
                 # for the outbound stream.
@@ -344,7 +344,7 @@ async def subsystem_transformer(*, loop, subsystem, kind, httpsession,
                 PRODUCED.inc()
 
                 TOTAL_TIME.observe(
-                    (datetime.datetime.now() - start_time).seconds())
+                    (datetime.datetime.now() - start_time).seconds)
 
     finally:
         logger.info('Shutting down')


### PR DESCRIPTION
- Fix `.seconds()` call
- Update k8s deployment configuration to use the latest version of the container