### PR TITLE
[DM-19424] Add notebook to characterize latency

### DIFF
--- a/k8s-cluster/kafka-efd-latency.ipynb
+++ b/k8s-cluster/kafka-efd-latency.ipynb
@@ -1,0 +1,173 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DM-EFD latency characterization\n",
+    "\n",
+    "This notebook shows how to get data from the InfluxDB API to characterize the total latency for a message from the time it is produced by SAL to the time it is written to InfluxDB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture packages\n",
+    "import sys\n",
+    "!{sys.executable} -m pip install matplotlib\n",
+    "!{sys.executable} -m pip install pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## InfluxDB URL and database to read from"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "INFLUXDB_API_URL = \"https://influxdb-efd-kafka.lsst.codes\"\n",
+    "INFLUXDB_DATABASE = \"efd\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "USERNAME = \"admin\"\n",
+    "PASSWORD = getpass.getpass(prompt='Password for user `{}`: '.format(username))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retrieving timestamps for a given topic\n",
+    "The following timestamps are available (the order reflects the actual message flow through the system) \n",
+    "\n",
+    "- **sal_ingested**: Timestamp when SAL ingested the message from the DDS bus.\n",
+    "- **sal_created**: Timestamp when SAL sends the message to the kafka brokers.\n",
+    "- **kafka_timestamp**: Timestamp right after the SAL transform step.\n",
+    "- **time**: Timestamp when the message is written to InfluxDB. Note that this timestamp depends on the InfluxDB Sink connector configuration. At the time of this writing the connector is configured to use the system current time as the InfluxDB timestamp. In the case that changes,  we'll create another timestamp to record the timestamp when the message is written to InfluxDB.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_timestamps(topic, past='15m'):\n",
+    "    \n",
+    "    query = 'SELECT \"sal_created\", \"sal_ingested\", \"kafka_timestamp\" FROM \"{}\\\".\"autogen\".\"{}\" where time > now()-{}'\n",
+    "    params={'q': query.format(INFLUXDB_DATABASE, topic, past), 'epoch': 'ms', 'chunked': '200000', 'u': USERNAME, 'p': PASSWORD}\n",
+    "    \n",
+    "    r = requests.post(url=INFLUXDB_API_URL + \"/query\", params=params)\n",
+    "    \n",
+    "    return r.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = get_timestamps(\"lsst.sal.MTM1M3_forceActuatorData\")['results'][0]['series'][0]\n",
+    "df = pd.DataFrame.from_records(data['values'], columns=data['columns'])\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Latency and time in seconds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['latency'] = (df['time'] - df['sal_created'])/1000\n",
+    "df['time_seconds'] = (df['time']-df['time'][0])/1000"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Latency characterization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "median = df.latency.median()\n",
+    "quantile99 = df.latency.quantile(.99)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "p = df.plot(x='time_seconds', y='latency', figsize=(15,3))\n",
+    "p.set_xlabel(\"Time (s)\")\n",
+    "p.set_ylabel(\"Latency (s)\")\n",
+    "p.text(50,df.latency.max()-0.1,\"Median={:.4f}s 99% percentile={:.2f}s\".format(median, quantile99))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This notebook was used to characterize the DM-EFD latency and serves as an example on how to retrieve data from InfluxDB using the HTTP API.

 