### PR TITLE
[DM-19655] Add JDBC plugin and oracle driver to kafka-connect

### DIFF
--- a/k8s-cluster/cp-kafka-connect/Dockerfile
+++ b/k8s-cluster/cp-kafka-connect/Dockerfile
@@ -1,17 +1,25 @@
 # Builds a docker image for Confluent Platform Kafka Connect with InfluxDB Sink
 # Connector from Landoop https://docs.lenses.io/connectors/sink/influx.html
+# and adds the Oracle JDBC driver for the Confluent JDBC Sink connector
 
-FROM confluentinc/cp-kafka-connect-base
+FROM confluentinc/cp-kafka-connect:latest
 
 MAINTAINER afausti@lsst.org
 
-ARG CONNECTOR
-ARG CONNECTOR_VERSION
-ARG VERSION
+# Add InfluxDB Sink Connector from Landoop
 
-RUN echo "Installing InfluxDB Sink Connector from Landoop ..." && \
-wget https://github.com/landoop/stream-reactor/releases/download/${CONNECTOR_VERSION}/kafka-connect-${CONNECTOR}-${CONNECTOR_VERSION}-${VERSION}-all.tar.gz && \
+ARG CONNECTOR="influxdb"
+ARG CONNECTOR_VERSION="1.2.1"
+ARG VERSION="2.1.0"
+
+RUN wget https://github.com/landoop/stream-reactor/releases/download/${CONNECTOR_VERSION}/kafka-connect-${CONNECTOR}-${CONNECTOR_VERSION}-${VERSION}-all.tar.gz && \
 tar -xvf kafka-connect-${CONNECTOR}-${CONNECTOR_VERSION}-${VERSION}-all.tar.gz -C . && \
 mkdir -p /etc/landoop/jars/lib && \
 mv kafka-connect-${CONNECTOR}-${CONNECTOR_VERSION}-${VERSION}-all.jar /etc/landoop/jars/lib && \
 chmod -R ag+w /etc/landoop/jars/lib
+
+# Add the Oracle JDBC driver for the Confluent JDBC Sink Connector
+# Download the Oracle JDBC driver (ojdbc8.jar) from
+# https://www.oracle.com/technetwork/database/application-development/jdbc/downloads/index.html
+
+COPY ./ojdbc8.jar /usr/share/java/kafka-connect-jdbc/

--- a/k8s-cluster/cp-kafka-connect/build-docker.sh
+++ b/k8s-cluster/cp-kafka-connect/build-docker.sh
@@ -1,16 +1,8 @@
 #!/usr/bin/env bash
 
-CONNECTOR="influxdb"
-CONNECTOR_VERSION="1.2.1"
-VERSION="2.1.0"
 IMAGE="lsstsqre/cp-kafka-connect"
 IMAGE_TAG="latest"
 
-echo "Building CP Kafka Connect with InfluxDB Sink Connector from Landoop"
-docker build \
-    --build-arg CONNECTOR=${CONNECTOR} \
-    --build-arg CONNECTOR_VERSION=${CONNECTOR_VERSION} \
-    --build-arg VERSION=${VERSION} \
-    -t ${IMAGE}:${IMAGE_TAG} \
-    -f Dockerfile .
+echo "Building Kafka Connect image"
+docker build -t ${IMAGE}:${IMAGE_TAG} -f Dockerfile .
 docker push ${IMAGE}:${IMAGE_TAG}

--- a/k8s-cluster/cp-kafka-connect/create_connector.sh
+++ b/k8s-cluster/cp-kafka-connect/create_connector.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -x
+
+echo "Create a kafka-connect connector"
+curl -s -X POST -H 'Content-Type: application/json' \
+--data @$1 http://confluent-cp-kafka-connect:8083/connectors

--- a/k8s-cluster/cp-kafka-connect/jdbc-connector.json
+++ b/k8s-cluster/cp-kafka-connect/jdbc-connector.json
@@ -1,0 +1,18 @@
+{
+  "name" : "oracle-sink",
+  "config" : {
+  "connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",
+  "topics": "lsst.sal.MTM1M3_gyroData",
+  "tasks.max": 1,
+  "connection.url": "jdbc:oracle:thin:@lsst-oradb-test.ncsa.illinois.edu:1521:kafka_efd",
+  "connection.user": "kafka_efd",
+  "connection.password": "---",
+  "insert.mode": "insert",
+  "batch.size": 3000,
+  "table.name.format": "${topic}",
+  "auto.create": true,
+  "auto.evolve": false,
+  "max.retries": 10,
+  "retry.backoff.ms": 3000
+  }
+}

--- a/k8s-cluster/cp-kafka-connect/remove-connector.sh
+++ b/k8s-cluster/cp-kafka-connect/remove-connector.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -x
+
+echo "Remove a kafka-connect connector"
+curl -s -X DELETE -H 'Content-Type: application/json' \
+http://confluent-cp-kafka-connect:8083/connectors/$1


### PR DESCRIPTION
- This PR makes the Confluent JDBC connector work with Oracle and adds a configuration example for one topic, enough to test the JDBC connector.
- Add scripts to facilitate the creation/removal of the connector using the Kafka Connect REST API.